### PR TITLE
Untested Multi-Architecture Support

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["x86_64", "i386", "aarch64"]
+  "only-arches": ["x86_64", "aarch64"]
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64", "i386", "aarch64"]
 }

--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -25,6 +25,114 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="v6.61" date="2022-06-17">
+      <description>
+        <p>ReaSamploMatic5000</p>
+        <ul>
+          <li>add Media Explorer options to set a MIDI note or channel to assign when inserting media into sampler, incrementing if inserting on new track</li>
+          <li>add Media Explorer option to assign MIDI note based on detected pitch when inserting media into sampler</li>
+          <li>when inserting into sampler and detecting pitch, assign sampler pitch start rather than note start (so the sample can be played at different pitches, correctly tuned)</li>
+          <li>add pitch detection</li>
+          <li>display note names for pitch offset</li>
+          <li>if sample detected pitch is out of range of pitch start parameter, add octaves to note start parameter as needed</li>
+          <li>support sorting sample list by detected pitch</li>
+          <li>support typing in sample pitch</li>
+          <li>when inserting media from media explorer into an existing sampler instance, obey preferences to apply volume/pitch adjustment</li>
+        </ul>
+
+        <p>MIDI</p>
+        <ul>
+          <li>fix exporting type 1 MIDI that has both embedded cues and key signature changes</li>
+          <li>fix key signature export</li>
+        </ul>
+
+        <p>Render</p>
+        <ul>
+          <li>always display one momentary, one short-term, and one integrated render statistic in render dialog</li>
+          <li>fully cancel render queue when user clicks "cancel all"</li>
+          <li>make clearer in preferences that either LUFS or RMS, both not both, will be calculated/displayed for a given period (momentary, short-term, or integrated)</li>
+        </ul>
+
+        <p>Spectral edits</p>
+        <ul>
+          <li>fix incomplete loading of certain complex shapes</li>
+          <li>prevent resizing regions into entirely negative space</li>
+          <li>when inserting a new edit, select the edit by default</li>
+        </ul>
+
+        <p>Video</p>
+        <ul>
+          <li>fix some WMF decoding issues that were un-fixed by a different WMF decoding fix in v6.60</li>
+          <li>hopefully improve WMF compatibility further</li>
+          <li>fix performance/stability issues when using AVFoundation decoding on a track that does not use media buffering</li>
+        </ul>
+
+        <p>Actions</p>
+        <ul>
+          <li>fix potential crash when running action to normalize selected items with no items selected</li>
+        </ul>
+
+        <p>Drawing</p>
+        <ul>
+          <li>various drawing integer overflow fixes with non-sensical values</li>
+        </ul>
+
+        <p>Envelopes</p>
+        <ul>
+          <li>fix pencil-drawing take envelopes on stretched media items in certain situations</li>
+        </ul>
+
+        <p>FX</p>
+        <ul>
+          <li>ensure FX parameter modulation/linking are preserved after undo after loading FX chains</li>
+        </ul>
+
+        <p>FX browser</p>
+        <ul>
+          <li>include LV2i in Instruments list</li>
+        </ul>
+
+        <p>Master track</p>
+        <ul>
+          <li>fix loudness meter readout tooltip label in mixer</li>
+        </ul>
+
+        <p>Media explorer</p>
+        <ul>
+          <li>add a hidden accessible text field for pitch detection output</li>
+        </ul>
+
+        <p>ReaScript</p>
+        <ul>
+          <li>fix Track/TakeFX_AddByName() matching existing instances when using FX-type prefix</li>
+        </ul>
+
+        <p>Recording</p>
+        <ul>
+          <li>fix pre-fx/pre-fader output recording when live FX multiprocessing is disabled</li>
+        </ul>
+
+        <p>Theme</p>
+        <ul>
+          <li>hit test vol/pan/width labels last even when they are above other controls</li>
+        </ul>
+
+        <p>Undo</p>
+        <ul>
+          <li>do not process deferred undo points if in the middle of a mouse edit</li>
+        </ul>
+
+        <p>VST</p>
+        <ul>
+          <li>improve initial size behavior with plug-ins that adjust size when UI opens (Kee Bass)</li>
+        </ul>
+
+        <p>Windows</p>
+        <ul>
+          <li>improve appearance of checked bitmap menu items (fades, note head shapes, etc)</li>
+        </ul>
+      </description>
+    </release>
     <release version="v6.58" date="2022-05-18">
       <description>
         <p>Video</p>

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -44,8 +44,10 @@ modules:
       - ln -sf /app/REAPER/reaper /app/bin/reaper 
     sources:
       - type: archive
-        url: https://www.reaper.fm/files/6.x/reaper658_linux_x86_64.tar.xz
-        sha256: 8d18e110a75f99640161c852acf3610dfeb2a2712a49df2012888236e89dcac3
+        url: https://www.reaper.fm/files/6.x/reaper661_linux_x86_64.tar.xz
+        sha256: 2e9d84564cb5fabb9cf3a2dd326be16488aca189743b176456737787fbb4f484
+        only-arches:
+          - x86_64
       - type: file
         path: fm.reaper.Reaper.desktop
       - type: file

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -49,11 +49,6 @@ modules:
         only-arches:
           - x86_64
       - type: archive
-        url: https://www.reaper.fm/files/6.x/reaper661_linux_i686.tar.xz
-        sha256: c1d0cca4a8ede79f5a99789c515b9daa94f101fdb6d66e450545c95030445ec4
-        only-arches:
-          - i386
-      - type: archive
         url: https://www.reaper.fm/files/6.x/reaper661_linux_aarch64.tar.xz
         sha256: b0f2c2300fffc407565e363bfbe47a78b592e7a662d2efbd8eeec9948086bd57
         only-arches:

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -48,6 +48,16 @@ modules:
         sha256: 2e9d84564cb5fabb9cf3a2dd326be16488aca189743b176456737787fbb4f484
         only-arches:
           - x86_64
+      - type: archive
+        url: https://www.reaper.fm/files/6.x/reaper661_linux_i686.tar.xz
+        sha256: c1d0cca4a8ede79f5a99789c515b9daa94f101fdb6d66e450545c95030445ec4
+        only-arches:
+          - i386
+      - type: archive
+        url: https://www.reaper.fm/files/6.x/reaper661_linux_aarch64.tar.xz
+        sha256: b0f2c2300fffc407565e363bfbe47a78b592e7a662d2efbd8eeec9948086bd57
+        only-arches:
+          - aarch64
       - type: file
         path: fm.reaper.Reaper.desktop
       - type: file


### PR DESCRIPTION
This pull request adds support for:

- [x] 32-bit x86 (reaper.fm calls this "i686", but flatpak calls it "i386")
- [x] 64-bit ARM (aarch64)
- [ ] armv7l (I'm not sure if this is supported by flatpak or how to refer to it, so those changes are still uncommitted)

I do not have an aarch64 system to test this on, so someone who does should check this out before merging.

This includes the version update from #1, but I can create a version based on v6.58 if that would be preferable.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [ ] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
