### PR TITLE
Re-added flathub.json

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "only-arches": ["x86_64", "aarch64"]
+}

--- a/fm.reaper.Reaper.desktop
+++ b/fm.reaper.Reaper.desktop
@@ -1,7 +1,9 @@
 [Desktop Entry]
 Name=Reaper
 Exec=reaper
-Icon=fm.reaper.Reaper
+# Icon is validated at build time, but it doesn't extist yet because apply_extra
+# hasn't run yet.
+# Icon=/app/extra/REAPER/Resources/main.png
 Type=Application
 Comment=Digital Audio Workstation
 Categories=AudioVideo;Audio;Video;

--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -24,6 +24,31 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="v6.64" date="2022-07-13">
+      <ul>
+        <li>Render</li>
+        <li>GIF</li>
+        <li>JSFX</li>
+        <li>Media explorer</li>
+        <li>Region manager</li>
+        <li>Batch converter</li>
+        <li>Help menu</li>
+        <li>Master track</li>
+        <li>Normalization</li>
+        <li>ReaScript</li>
+        <li>Resampling</li>
+        <li>Theme</li>
+        <li>Wave64</li>
+        <li>Windows</li>
+      </ul>
+    </release>
+    <release version="v6.63" date="2022-07-03">
+      <ul>
+        <li>Batch converter</li>
+        <li>Render</li>
+        <li>Windows</li>
+      </ul>
+    </release>
     <release version="v6.62" date="2022-07-01">
       <description>
         <p>The following components were updated:</p>

--- a/fm.reaper.Reaper.metainfo.xml
+++ b/fm.reaper.Reaper.metainfo.xml
@@ -24,6 +24,34 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="v6.62" date="2022-07-01">
+      <description>
+        <p>The following components were updated:</p>
+        <ul>
+          <li>FX</li>
+          <li>Linux</li>
+          <li>Media explorer</li>
+          <li>Razor edits</li>
+          <li>ReaEQ</li>
+          <li>Render</li>
+          <li>VST</li>
+          <li>WAV</li>
+          <li>Windows</li>
+          <li>Actions window</li>
+          <li>Automation</li>
+          <li>Batch converter</li>
+          <li>macOS/Linux</li>
+          <li>Normalization</li>
+          <li>Notation editor</li>
+          <li>Pan</li>
+          <li>Project markers</li>
+          <li>ReaControlMIDI</li>
+          <li>ReaVerb</li>
+          <li>Spectral edits</li>
+        </ul>
+        <p>More details can be found on the official Reaper website.</p>
+      </description>
+    </release>
     <release version="v6.61" date="2022-06-17">
       <description>
         <p>The following components were updated:</p>

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -60,15 +60,15 @@ modules:
           - rm -rf /app/extra/export/share/reaper_linux_*
       - type: extra-data
         filename: reaper.tar.xz
-        url: https://www.reaper.fm/files/6.x/reaper662_linux_x86_64.tar.xz
-        size: 11680436
-        sha256: 08780e59f9945a18cfd09acb784b34f600fe7933f5462c63c4e91282e0a41162
+        url: https://www.reaper.fm/files/6.x/reaper664_linux_x86_64.tar.xz
+        size: 11686496
+        sha256: a60e1caa17c886d1ca5b8c7fa7f41379906a548656e836ec1c546faadf1f84d4
         only-arches: [x86_64]
       - type: extra-data
         filename: reaper.tar.xz
-        url: https://www.reaper.fm/files/6.x/reaper662_linux_aarch64.tar.xz
-        size: 10467308
-        sha256: 195ad50638785246fbd6b8e45ced8dfe8c953c7005b3d276dae4ad88e122ea00
+        url: https://www.reaper.fm/files/6.x/reaper664_linux_aarch64.tar.xz
+        size: 10470672
+        sha256: 6f3f06b6c0ba6dc7d43b4718c2f70feaa34dd9491d553e5dbfebe8b2920ea620
         only-arches: [aarch64]
       - type: script
         dest-filename: reaper

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -62,15 +62,15 @@ modules:
           - rm -rf export/share/reaper_linux_*
       - type: extra-data
         filename: reaper.tar.xz
-        url: https://www.reaper.fm/files/6.x/reaper661_linux_x86_64.tar.xz
-        size: 11675288
-        sha256: 2e9d84564cb5fabb9cf3a2dd326be16488aca189743b176456737787fbb4f484
+        url: https://www.reaper.fm/files/6.x/reaper662_linux_x86_64.tar.xz
+        size: 11680436
+        sha256: 08780e59f9945a18cfd09acb784b34f600fe7933f5462c63c4e91282e0a41162
         only-arches: [x86_64]
       - type: extra-data
         filename: reaper.tar.xz
-        url: https://www.reaper.fm/files/6.x/reaper661_linux_aarch64.tar.xz
-        size: 10463064
-        sha256: b0f2c2300fffc407565e363bfbe47a78b592e7a662d2efbd8eeec9948086bd57
+        url: https://www.reaper.fm/files/6.x/reaper662_linux_aarch64.tar.xz
+        size: 10467308
+        sha256: 195ad50638785246fbd6b8e45ced8dfe8c953c7005b3d276dae4ad88e122ea00
         only-arches: [aarch64]
       - type: script
         dest-filename: reaper

--- a/fm.reaper.Reaper.yml
+++ b/fm.reaper.Reaper.yml
@@ -41,25 +41,23 @@ modules:
       # Install wrapper script to run application
       - install -D reaper /app/bin/reaper
       # Add desktop integration
-      - install -Dm644 fm.reaper.Reaper.desktop share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 fm.reaper.Reaper.desktop /app/share/applications/${FLATPAK_ID}.desktop
       # Install flatpak metadata
-      - install -Dm644 fm.reaper.Reaper.metainfo.xml share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - install -Dm644 fm.reaper.Reaper.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
     sources:
       - type: script
         dest-filename: apply_extra
         commands:
           # Extract downnloaded tarball
           - mkdir -p export/share
-          - tar xf reaper.tar.xz -C export/share
+          - tar xf reaper.tar.xz -C /app/extra/export/share
           - rm -f reaper.tar.xz
           # Run installer script
           - cd export/share/reaper_linux_*
           - ./install-reaper.sh --quiet --install /app/extra
-          # Save icon where the .desktop file can find it
-          - install -Dm644 /app/extra/REAPER/Resources/main.png share/icons/hicolor/256x256/apps/fm.reaper.Reaper.png
           # Clean up temp tiles
           - cd ../../../
-          - rm -rf export/share/reaper_linux_*
+          - rm -rf /app/extra/export/share/reaper_linux_*
       - type: extra-data
         filename: reaper.tar.xz
         url: https://www.reaper.fm/files/6.x/reaper662_linux_x86_64.tar.xz


### PR DESCRIPTION
I removed flathub.json because of [this comment](https://github.com/flathub/flathub/pull/3222#discussion_r910831164), but it looks like it may be necessary after all. According to [the docs](https://github.com/flathub/flathub/wiki/App-Maintenance#limiting-the-set-of-architectures-to-build-on), we still need to declare architectures because we're not supporting i386. VS Code flatpak [does the same](https://github.com/flathub/com.visualstudio.code/blob/master/flathub.json).